### PR TITLE
Implement trade and developer endpoints

### DIFF
--- a/core/TEN_elite_commands_FULL.py
+++ b/core/TEN_elite_commands_FULL.py
@@ -20,20 +20,69 @@ def status():
 
 @app.route("/fire", methods=["POST"])
 def fire():
+    data = request.get_json(silent=True) or {}
     payload = {
-        "symbol": "XAUUSD",
-        "volume": 0.10,
-        "sl": 1975.00,
-        "tp": 1990.00,
-        "comment": "HydraX Commander",
-        "action": "buy"
+        "symbol": data.get("symbol"),
+        "volume": data.get("volume"),
+        "sl": data.get("sl"),
+        "tp": data.get("tp"),
+        "comment": data.get("comment"),
+        "action": data.get("action")
     }
+
+    if not all(payload.values()):
+        return jsonify({"status": "error", "message": "Missing trade parameters"}), 400
+
     try:
         resp = requests.post("http://127.0.0.1:9000", json=payload)
         resp.raise_for_status()
-        return jsonify({"status": "success", "response": resp.text}), 200
+        try:
+            result = resp.json()
+        except ValueError:
+            result = resp.text
+        return jsonify({"status": "success", "result": result}), 200
     except requests.RequestException as e:
         return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@app.route("/dev", methods=["POST"])
+def dev():
+    if request.headers.get("X-Dev-Key") != "SECRET123":
+        return jsonify({"status": "error", "message": "Unauthorized"}), 401
+
+    data = request.get_json(silent=True) or {}
+    command = data.get("command")
+
+    if command == "status":
+        return jsonify({"status": "ok", "timestamp": datetime.utcnow().isoformat() + "Z"}), 200
+    elif command == "testfire":
+        payload = {
+            "symbol": data.get("symbol"),
+            "volume": data.get("volume"),
+            "sl": data.get("sl"),
+            "tp": data.get("tp"),
+            "comment": data.get("comment"),
+            "action": data.get("action")
+        }
+
+        if not all(payload.values()):
+            return jsonify({"status": "error", "message": "Missing trade parameters"}), 400
+
+        try:
+            resp = requests.post("http://127.0.0.1:9000", json=payload)
+            resp.raise_for_status()
+            try:
+                result = resp.json()
+            except ValueError:
+                result = resp.text
+            return jsonify({"status": "success", "result": result}), 200
+        except requests.RequestException as e:
+            return jsonify({"status": "error", "message": str(e)}), 500
+    elif command == "reload":
+        os.system("systemctl restart hydrax || true")
+        return jsonify({"status": "reloaded"}), 200
+    else:
+        return jsonify({"status": "error", "message": "Unknown command"}), 400
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))


### PR DESCRIPTION
## Summary
- add POST `/fire` route to relay trades to local MT5 bridge
- add secure developer endpoint `/dev` with status, testfire, and reload commands

## Testing
- `python -m py_compile core/TEN_elite_commands_FULL.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684f19674bf4832da4361bcd5a97e30b