### PR TITLE
Improve logging path handling

### DIFF
--- a/core/TEN_elite_commands_FULL.py
+++ b/core/TEN_elite_commands_FULL.py
@@ -14,7 +14,8 @@ import json
 
 BRIDGE_URL = os.environ.get("BRIDGE_URL") or "http://127.0.0.1:9000"
 DEV_API_KEY = os.environ.get("DEV_API_KEY") or "SECRET123"
-LOG_FILE = os.environ.get("DEV_LOG_FILE") or "dev_log.txt"
+_default_log = os.path.join(os.path.dirname(__file__), "dev_log.txt")
+LOG_FILE = os.environ.get("DEV_LOG_FILE") or _default_log
 
 app = Flask(__name__)
 
@@ -29,9 +30,11 @@ def _log_action(route, payload, result):
     """Append a single log line with timestamp, route, payload and result."""
     timestamp = datetime.utcnow().isoformat() + "Z"
     try:
-        with open(LOG_FILE, "a") as f:
-            f.write(f"[{timestamp}] {route} \u2192 {result.upper()} "
-                    f"{json.dumps(payload, separators=(',', ':'))}\n")
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(
+                f"[{timestamp}] {route} \u2192 {result.upper()} "
+                f"{json.dumps(payload, separators=(',', ':'))}\n"
+            )
     except Exception:
         # Logging failures should not affect API responses
         pass
@@ -184,7 +187,7 @@ def logs():
         }), 401
 
     try:
-        with open(LOG_FILE, "r") as f:
+        with open(LOG_FILE, "r", encoding="utf-8") as f:
             lines = [line.rstrip() for line in f.readlines()]
         last_lines = lines[-50:]
         return jsonify({


### PR DESCRIPTION
## Summary
- keep log file in module dir unless overridden
- ensure UTF-8 encoding when reading/writing log file

## Testing
- `python -m py_compile core/TEN_elite_commands_FULL.py`

------
https://chatgpt.com/codex/tasks/task_e_684f32c0791c832dbc727cf251f7a347